### PR TITLE
Change hostname from kindle-pw6 to kindle

### DIFF
--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -16,7 +16,7 @@ sleep 3
 # Connect with auth key if available
 if [ -f auth.key ] && grep -q "^tskey-" auth.key; then
     AUTH_KEY=$(grep "^tskey-" auth.key | head -1 | tr -d ' ' | tr -d '#')
-    ./tailscale up --auth-key="$AUTH_KEY" --hostname=kindle-pw6 --accept-routes > tailscale.log 2>&1
+    ./tailscale up --auth-key="$AUTH_KEY" --hostname=kindle --accept-routes > tailscale.log 2>&1
 else
-    ./tailscale up --hostname=kindle-pw6 --accept-routes > tailscale.log 2>&1
+    ./tailscale up --hostname=kindle --accept-routes > tailscale.log 2>&1
 fi


### PR DESCRIPTION
Hi! I'm using your plugin on a pw5 and was surprised to see the hostname, lol.

I think omitting the generation would be a good idea.

Thank you for your work!