### PR TITLE
feat: add support for outbound connections

### DIFF
--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -10,7 +10,7 @@ killall tailscaled 2>/dev/null || true
 sleep 2
 
 # Start daemon
-nohup ./tailscaled --statedir=/mnt/us/tailscale/bin/ -tun userspace-networking > tailscaled.log 2>&1 &
+nohup ./tailscaled --statedir=/mnt/us/tailscale/bin/ > tailscaled.log 2>&1 &
 sleep 3
 
 # Connect with auth key if available


### PR DESCRIPTION
This PR solves this issue: #3 (at least for my PW5)

This was figured out in the tailscale_kual project, [refer here](https://github.com/mitanshu7/tailscale_kual/issues/2#issuecomment-2710486540)

> The -tun userspace-networking has been removed - this allows the tailscaled program to create a network tunnel called tailscale0 and automatically configure the device's iptables rules.

Btw, great idea - I was using the KUAL one and its more convenient to be able to handle it from directly within KOReader!


