### PR TITLE
Fix x509 "certificate signed by unknown authority" on Kobo

### DIFF
--- a/bin/install-tailscale.sh
+++ b/bin/install-tailscale.sh
@@ -66,4 +66,9 @@ mv -f tailscale_*/tailscale tailscale_*/tailscaled ./ 2>/dev/null || true
 rm -rf tailscale_* 2>/dev/null || true
 chmod +x ./tailscale ./tailscaled 2>/dev/null || true
 [ -f auth.key ] || : > auth.key
+
+if [ ! -f "$BIN_DIR/ca-certificates.crt" ]; then
+    busybox wget -q -O "$BIN_DIR/ca-certificates.crt" "http://curl.se/ca/cacert.pem" 2>/dev/null || true
+fi
+
 exit 0

--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -9,6 +9,10 @@ cd "$BIN_DIR" || exit 1
 [ -f ./tailscaled ] || exit 1
 [ -f ./tailscale ] || exit 1
 
+if [ -f "$BIN_DIR/ca-certificates.crt" ]; then
+    export SSL_CERT_FILE="$BIN_DIR/ca-certificates.crt"
+fi
+
 # Stop any running instances
 ./tailscale down >/dev/null 2>&1 || true
 killall tailscaled 2>/dev/null || true
@@ -62,10 +66,6 @@ TUN_FLAG="--tun=userspace-networking"
 
 # Wait for daemon socket to become available
 sleep 3
-
-if [ -f "$BIN_DIR/ca-certificates.crt" ]; then
-    export SSL_CERT_FILE="$BIN_DIR/ca-certificates.crt"
-fi
 
 # Get current hostname (if any)
 HOSTNAME=""

--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -63,6 +63,10 @@ TUN_FLAG="--tun=userspace-networking"
 # Wait for daemon socket to become available
 sleep 3
 
+if [ -f "$BIN_DIR/ca-certificates.crt" ]; then
+    export SSL_CERT_FILE="$BIN_DIR/ca-certificates.crt"
+fi
+
 # Get current hostname (if any)
 HOSTNAME=""
 if ./tailscale status --json >/dev/null 2>&1; then


### PR DESCRIPTION
E-reader firmware typically ships without a CA certificate bundle. When tailscaled runs as an HTTP CONNECT proxy (--outbound-http-proxy-listen), Go's crypto/x509 package fails to verify upstream TLS certificates, producing the following errors in `tailscaled.log`.

```log
2026/04/06 07:22:55 http: proxy error: context canceled
2026/04/06 07:23:08 http: proxy error: context canceled
2026/04/06 07:23:13 magicsock: closing connection to derp-11 (idle), age 1m15s
2026/04/06 07:23:13 magicsock: 1 active derp conns: derp-1=cr2m0s,wr2m0s
2026/04/06 07:23:16 netmap: suggested exit node:  ()
2026/04/06 07:23:18 http: proxy error: context canceled
2026/04/06 07:23:23 http: proxy error: tls: failed to verify certificate: x509: certificate signed by unknown authority
2026/04/06 07:23:23 http: proxy error: tls: failed to verify certificate: x509: certificate signed by unknown authority
2026/04/06 07:23:26 http: proxy error: tls: failed to verify certificate: x509: certificate signed by unknown authority
2026/04/06 07:23:26 http: proxy error: tls: failed to verify certificate: x509: certificate signed by unknown authority
```

This PR, fixes this issue by doing the following things.
- Downloads the Mozilla CA bundle (cacert.pem) during `install-tailscale.sh`
- Sets SSL_CERT_FILE in the start scripts so tailscaled can find it

I've verified that this method works on my own device (Kobo Libra Color). Please feel free to run necessary tests on other devices before merging.