### PR TITLE
Exit node and automatic enabling of HTTP proxy support

### DIFF
--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -77,10 +77,19 @@ if [ -f auth.key ] && grep -q "^tskey-" auth.key; then
     AUTH_KEY=$(grep "^tskey-" auth.key | head -1 | tr -d ' ' | tr -d '#')
 fi
 
+quote_arg() {
+    printf "%s" "$1" | sed "s/'/'\\\\''/g; 1s/^/'/; \$s/\$/'/"
+}
+
+EXIT_NODE_FLAGS=""
+if [ "${USE_EXIT_NODE:-0}" = "1" ] && [ -n "${EXIT_NODE:-}" ]; then
+    EXIT_NODE_FLAGS=" --exit-node=$(quote_arg "$EXIT_NODE") --exit-node-allow-lan-access"
+fi
+
 # Build command
 # --accept-dns=false: prevent tailscale from attempting to modify /etc/resolv.conf (read-only on PocketBook).
 # --netfilter-mode=off: avoid nftables/iptables reconfig stalls on constrained e-reader kernels.
-CMD="./tailscale up $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off"
+CMD="./tailscale up $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off$EXIT_NODE_FLAGS"
 [ -n "$AUTH_KEY" ] && CMD="$CMD --auth-key=\"$AUTH_KEY\""
 
 # Run with stdin from /dev/null to prevent tailscale up from hanging if it
@@ -95,7 +104,7 @@ if [ $RC -ne 0 ]; then
         if [ -n "$SUG_HOST" ]; then
             HOST_FLAG="--hostname=$SUG_HOST"
         fi
-        CMD="./tailscale up $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off"
+        CMD="./tailscale up $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off$EXIT_NODE_FLAGS"
         [ -n "$AUTH_KEY" ] && CMD="$CMD --auth-key=\"$AUTH_KEY\""
         sh -c "$CMD" < /dev/null > tailscale.log 2>&1
         RC=$?

--- a/bin/start_tailscale_headscale.sh
+++ b/bin/start_tailscale_headscale.sh
@@ -74,10 +74,19 @@ if [ -f auth.key ] && grep -q "^tskey-" auth.key; then
     AUTH_KEY=$(grep "^tskey-" auth.key | head -1 | tr -d ' ' | tr -d '#')
 fi
 
+quote_arg() {
+    printf "%s" "$1" | sed "s/'/'\\\\''/g; 1s/^/'/; \$s/\$/'/"
+}
+
+EXIT_NODE_FLAGS=""
+if [ "${USE_EXIT_NODE:-0}" = "1" ] && [ -n "${EXIT_NODE:-}" ]; then
+    EXIT_NODE_FLAGS=" --exit-node=$(quote_arg "$EXIT_NODE") --exit-node-allow-lan-access"
+fi
+
 # Build command with login-server
 # --accept-dns=false: prevent tailscale from attempting to modify /etc/resolv.conf (read-only on PocketBook)
 # --netfilter-mode=off: avoid nftables/iptables reconfig stalls on constrained e-reader kernels.
-CMD="./tailscale up --login-server=\"$HS_URL\" $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off"
+CMD="./tailscale up --login-server=\"$HS_URL\" $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off$EXIT_NODE_FLAGS"
 [ -n "$AUTH_KEY" ] && CMD="$CMD --auth-key=\"$AUTH_KEY\""
 
 sh -c "$CMD" < /dev/null > tailscale.log 2>&1
@@ -90,7 +99,7 @@ if [ $RC -ne 0 ]; then
         if [ -n "$SUG_HOST" ]; then
             HOST_FLAG="--hostname=$SUG_HOST"
         fi
-        CMD="./tailscale up --login-server=\"$HS_URL\" $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off"
+        CMD="./tailscale up --login-server=\"$HS_URL\" $HOST_FLAG --accept-routes --accept-dns=false --netfilter-mode=off$EXIT_NODE_FLAGS"
         [ -n "$AUTH_KEY" ] && CMD="$CMD --auth-key=\"$AUTH_KEY\""
         sh -c "$CMD" < /dev/null > tailscale.log 2>&1
         RC=$?

--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,7 @@ local json = require("json")
 local TailscalePlugin = WidgetContainer:extend{
     name = "tailscale",
     is_doc_only = false,
+    http_proxy_url = "http://127.0.0.1:1056",
 }
 
 --- Detect CPU architecture for Tailscale binary download.
@@ -46,6 +47,8 @@ function TailscalePlugin:init()
     self.settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/tailscale.lua")
     self.settings:readSetting("use_exit_node", false)
     self.settings:readSetting("exit_node", "")
+    self.settings:readSetting("auto_http_proxy", false)
+    self.settings:readSetting("http_proxy_backup_active", false)
     
     -- Detect platform-specific paths
     self.ts_dir, self.ts_arch = self:detectPlatform()
@@ -78,6 +81,110 @@ function TailscalePlugin:getStartEnvironment()
         end
     end
     return env
+end
+
+function TailscalePlugin:commandSucceeded(ok, reason, code)
+    if ok == true then
+        return true
+    end
+    if ok == 0 then
+        return true
+    end
+    if reason == "exit" and code == 0 then
+        return true
+    end
+    return false
+end
+
+function TailscalePlugin:runStartScript(script)
+    local ok, reason, code = os.execute(self:getStartEnvironment() .. " " .. self:shellQuote(script))
+    return self:commandSucceeded(ok, reason, code)
+end
+
+function TailscalePlugin:getNetworkManager()
+    local ok, network_mgr = pcall(require, "ui/network/manager")
+    if ok then
+        return network_mgr
+    end
+    logger.warn("Tailscale plugin: failed to load NetworkMgr for HTTP proxy management")
+    return nil
+end
+
+function TailscalePlugin:saveHTTPProxyBackup()
+    if self.settings:readSetting("http_proxy_backup_active") then
+        return
+    end
+
+    self.settings:saveSetting("http_proxy_backup_enabled", G_reader_settings:readSetting("http_proxy_enabled") and true or false)
+    self.settings:saveSetting("http_proxy_backup_value", G_reader_settings:readSetting("http_proxy") or "")
+    self.settings:saveSetting("http_proxy_backup_active", true)
+    self:flushSettings()
+end
+
+function TailscalePlugin:enableHTTPProxyIfNeeded()
+    if not self.settings:readSetting("auto_http_proxy") then
+        return
+    end
+
+    local network_mgr = self:getNetworkManager()
+    if not network_mgr or not network_mgr.setHTTPProxy then
+        UIManager:show(InfoMessage:new{
+            text = _("Tailscale connected, but KOReader HTTP proxy could not be configured."),
+            timeout = 5
+        })
+        return
+    end
+
+    self:saveHTTPProxyBackup()
+    local ok = pcall(function()
+        network_mgr:setHTTPProxy(self.http_proxy_url)
+    end)
+    if not ok then
+        self:restoreHTTPProxyBackup(true)
+        UIManager:show(InfoMessage:new{
+            text = _("Tailscale connected, but KOReader HTTP proxy could not be configured."),
+            timeout = 5
+        })
+    end
+end
+
+function TailscalePlugin:restoreHTTPProxyBackup(silent)
+    if not self.settings:readSetting("http_proxy_backup_active") then
+        return
+    end
+
+    local network_mgr = self:getNetworkManager()
+    if not network_mgr or not network_mgr.setHTTPProxy then
+        if not silent then
+            UIManager:show(InfoMessage:new{
+                text = _("Tailscale disconnected, but KOReader HTTP proxy could not be restored."),
+                timeout = 5
+            })
+        end
+        return
+    end
+
+    local backup_enabled = self.settings:readSetting("http_proxy_backup_enabled")
+    local backup_value = self.settings:readSetting("http_proxy_backup_value") or ""
+    local ok = pcall(function()
+        if backup_enabled and backup_value ~= "" then
+            network_mgr:setHTTPProxy(backup_value)
+        else
+            network_mgr:setHTTPProxy(nil)
+        end
+    end)
+
+    if ok then
+        self.settings:saveSetting("http_proxy_backup_active", false)
+        self.settings:delSetting("http_proxy_backup_enabled")
+        self.settings:delSetting("http_proxy_backup_value")
+        self:flushSettings()
+    elseif not silent then
+        UIManager:show(InfoMessage:new{
+            text = _("Tailscale disconnected, but KOReader HTTP proxy could not be restored."),
+            timeout = 5
+        })
+    end
 end
 
 function TailscalePlugin:getBinDir()
@@ -205,6 +312,20 @@ function TailscalePlugin:addToMainMenu(menu_items)
                         end
                     },
                     {
+                        text = _("Automatically configure HTTP proxy"),
+                        keep_menu_open = true,
+                        checked_func = function()
+                            return self.settings and self.settings:readSetting("auto_http_proxy")
+                        end,
+                        callback = function(touchmenu_instance)
+                            self.settings:saveSetting("auto_http_proxy", not self.settings:readSetting("auto_http_proxy"))
+                            self:flushSettings()
+                            if touchmenu_instance and touchmenu_instance.updateItems then
+                                touchmenu_instance:updateItems()
+                            end
+                        end
+                    },
+                    {
                         text = _("Start with Headscale"),
                         callback = function()
                             -- Ensure a Headscale URL is configured before attempting to start
@@ -231,7 +352,9 @@ function TailscalePlugin:addToMainMenu(menu_items)
                             local s = io.open(script, "r")
                             if s then
                                 s:close()
-                                os.execute(self:getStartEnvironment() .. " " .. self:shellQuote(script))
+                                if self:runStartScript(script) then
+                                    self:enableHTTPProxyIfNeeded()
+                                end
                                 UIManager:show(InfoMessage:new{
                                     text = _("Started Tailscale (Headscale)"),
                                     timeout = 3
@@ -377,7 +500,9 @@ end
 
 function TailscalePlugin:startDaemon()
     -- Start full Tailscale (daemon + CLI connect) quietly
-    os.execute(self:getStartEnvironment() .. " " .. self:shellQuote(self.plugin_dir .. "/bin/start_tailscale.sh"))
+    if self:runStartScript(self.plugin_dir .. "/bin/start_tailscale.sh") then
+        self:enableHTTPProxyIfNeeded()
+    end
     UIManager:show(InfoMessage:new{
         text = _("Tailscale daemon started"),
         timeout = 2
@@ -420,7 +545,9 @@ function TailscalePlugin:connectTailscale()
         return
     end
     
-    os.execute(self:getStartEnvironment() .. " " .. self:shellQuote(self.plugin_dir .. "/bin/start_tailscale.sh"))
+    if self:runStartScript(self.plugin_dir .. "/bin/start_tailscale.sh") then
+        self:enableHTTPProxyIfNeeded()
+    end
     UIManager:show(InfoMessage:new{
         text = _("Tailscale connection started\nCheck " .. self:getLogPath() .. " for status"),
         timeout = 4
@@ -430,7 +557,8 @@ function TailscalePlugin:connectTailscale()
 end
 
 function TailscalePlugin:disconnectTailscale()
-    os.execute("TS_DIR=" .. self.ts_dir .. " " .. self.plugin_dir .. "/bin/stop_tailscale.sh")
+    os.execute("TS_DIR=" .. self:shellQuote(self.ts_dir) .. " " .. self:shellQuote(self.plugin_dir .. "/bin/stop_tailscale.sh"))
+    self:restoreHTTPProxyBackup()
     UIManager:show(InfoMessage:new{
         text = _("Tailscale disconnected"),
         timeout = 2

--- a/main.lua
+++ b/main.lua
@@ -3,6 +3,8 @@ local Device = require("device")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
+local LuaSettings = require("luasettings")
 local logger = require("logger")
 local _ = require("gettext")
 local json = require("json")
@@ -41,6 +43,9 @@ end
 function TailscalePlugin:init()
     logger.info("Tailscale plugin initializing")
     self.plugin_dir = DataStorage:getFullDataDir() .. "/plugins/tailscale.koplugin"
+    self.settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/tailscale.lua")
+    self.settings:readSetting("use_exit_node", false)
+    self.settings:readSetting("exit_node", "")
     
     -- Detect platform-specific paths
     self.ts_dir, self.ts_arch = self:detectPlatform()
@@ -50,6 +55,29 @@ function TailscalePlugin:init()
     if self.ui and self.ui.menu then
         self.ui.menu:registerToMainMenu(self)
     end
+end
+
+function TailscalePlugin:flushSettings()
+    if self.settings then
+        self.settings:flush()
+    end
+end
+
+function TailscalePlugin:shellQuote(value)
+    value = tostring(value or "")
+    return "'" .. value:gsub("'", "'\\''") .. "'"
+end
+
+function TailscalePlugin:getStartEnvironment()
+    local env = "TS_DIR=" .. self:shellQuote(self.ts_dir)
+    if self.settings and self.settings:readSetting("use_exit_node") then
+        local exit_node = self.settings:readSetting("exit_node") or ""
+        exit_node = exit_node:gsub("^%s+", ""):gsub("%s+$", "")
+        if exit_node ~= "" then
+            env = env .. " USE_EXIT_NODE=1 EXIT_NODE=" .. self:shellQuote(exit_node)
+        end
+    end
+    return env
 end
 
 function TailscalePlugin:getBinDir()
@@ -95,7 +123,7 @@ function TailscalePlugin:onToggleTailscale(callback)
 end
 
 function TailscalePlugin:onFlushSettings()
-    -- Load settings if any
+    self:flushSettings()
 end
 
 function TailscalePlugin:addToMainMenu(menu_items)
@@ -151,6 +179,32 @@ function TailscalePlugin:addToMainMenu(menu_items)
                         end
                     },
                     {
+                        text = _("Enable exit node"),
+                        keep_menu_open = true,
+                        checked_func = function()
+                            return self.settings and self.settings:readSetting("use_exit_node")
+                        end,
+                        callback = function(touchmenu_instance)
+                            self.settings:saveSetting("use_exit_node", not self.settings:readSetting("use_exit_node"))
+                            self:flushSettings()
+                            if touchmenu_instance and touchmenu_instance.updateItems then
+                                touchmenu_instance:updateItems()
+                            end
+                        end
+                    },
+                    {
+                        text_func = function()
+                            local exit_node = self.settings and self.settings:readSetting("exit_node") or ""
+                            if exit_node and exit_node ~= "" then
+                                return _("Exit node") .. ": " .. exit_node
+                            end
+                            return _("Exit node")
+                        end,
+                        callback = function()
+                            self:configureExitNode()
+                        end
+                    },
+                    {
                         text = _("Start with Headscale"),
                         callback = function()
                             -- Ensure a Headscale URL is configured before attempting to start
@@ -177,7 +231,7 @@ function TailscalePlugin:addToMainMenu(menu_items)
                             local s = io.open(script, "r")
                             if s then
                                 s:close()
-                                os.execute("TS_DIR=" .. self.ts_dir .. " " .. script)
+                                os.execute(self:getStartEnvironment() .. " " .. self:shellQuote(script))
                                 UIManager:show(InfoMessage:new{
                                     text = _("Started Tailscale (Headscale)"),
                                     timeout = 3
@@ -323,7 +377,7 @@ end
 
 function TailscalePlugin:startDaemon()
     -- Start full Tailscale (daemon + CLI connect) quietly
-    os.execute("TS_DIR=" .. self.ts_dir .. " " .. self.plugin_dir .. "/bin/start_tailscale.sh")
+    os.execute(self:getStartEnvironment() .. " " .. self:shellQuote(self.plugin_dir .. "/bin/start_tailscale.sh"))
     UIManager:show(InfoMessage:new{
         text = _("Tailscale daemon started"),
         timeout = 2
@@ -366,7 +420,7 @@ function TailscalePlugin:connectTailscale()
         return
     end
     
-    os.execute("TS_DIR=" .. self.ts_dir .. " " .. self.plugin_dir .. "/bin/start_tailscale.sh")
+    os.execute(self:getStartEnvironment() .. " " .. self:shellQuote(self.plugin_dir .. "/bin/start_tailscale.sh"))
     UIManager:show(InfoMessage:new{
         text = _("Tailscale connection started\nCheck " .. self:getLogPath() .. " for status"),
         timeout = 4
@@ -530,6 +584,46 @@ function TailscalePlugin:configureHeadscale()
         timeout = 8
     })
 end
+
+function TailscalePlugin:configureExitNode()
+    local exit_node = self.settings and self.settings:readSetting("exit_node") or ""
+    local dialog
+    dialog = InputDialog:new{
+        title = _("Exit node"),
+        input = exit_node or "",
+        input_hint = _("Hostname, MagicDNS name, or Tailscale IP"),
+        description = _("Route traffic through this Tailscale exit node when enabled."),
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(dialog)
+                    end,
+                },
+                {
+                    text = _("Save"),
+                    is_enter_default = true,
+                    callback = function()
+                        local value = dialog:getInputText() or ""
+                        value = value:gsub("^%s+", ""):gsub("%s+$", "")
+                        self.settings:saveSetting("exit_node", value)
+                        self:flushSettings()
+                        UIManager:close(dialog)
+                        UIManager:show(InfoMessage:new{
+                            text = _("Exit node saved. Restart Tailscale to apply."),
+                            timeout = 3
+                        })
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(dialog)
+    dialog:onShowKeyboard()
+end
+
 function TailscalePlugin:uninstallTailscale()
     UIManager:show(InfoMessage:new{
         text = _("Uninstalling Tailscale...\nThis will remove all files and stop the service."),


### PR DESCRIPTION
Added ability to specify an exit node as well as a check box to automatically enable the HTTP proxy when connecting to tailscale